### PR TITLE
Fix profile import errors

### DIFF
--- a/Connector/Job/JobParameters/ConstraintCollectionProvider/ReferenceData.php
+++ b/Connector/Job/JobParameters/ConstraintCollectionProvider/ReferenceData.php
@@ -111,17 +111,15 @@ class ReferenceData implements ConstraintCollectionProviderInterface
                         ),
                     ],
                     'enclosure'  => [
-                        [
-                            new NotBlank(['groups' => ['Default', 'FileConfiguration']]),
-                            new Choice(
-                                [
-                                    'strict' => true,
-                                    'choices' => ['"', "'"],
-                                    'message' => 'The value must be one of " or \'',
-                                    'groups'  => ['Default', 'FileConfiguration'],
-                                ]
-                            ),
-                        ],
+                        new NotBlank(['groups' => ['Default', 'FileConfiguration']]),
+                        new Choice(
+                            [
+                                'strict' => true,
+                                'choices' => ['"', "'"],
+                                'message' => 'The value must be one of " or \'',
+                                'groups'  => ['Default', 'FileConfiguration'],
+                            ]
+                        ),
                     ],
                     'withHeader' => new Type(
                         [

--- a/Connector/Job/JobParameters/ConstraintCollectionProvider/ReferenceData.php
+++ b/Connector/Job/JobParameters/ConstraintCollectionProvider/ReferenceData.php
@@ -129,6 +129,7 @@ class ReferenceData implements ConstraintCollectionProviderInterface
                             'groups' => ['Default', 'FileConfiguration'],
                         ]
                     ),
+                    'uploadAllowed' => new Type('bool'),
                     'users_to_notify' => [
                         new Type('array'),
                         new All(new Type('string')),

--- a/Connector/Job/JobParameters/DefaultValuesProvider/ReferenceData.php
+++ b/Connector/Job/JobParameters/DefaultValuesProvider/ReferenceData.php
@@ -1,9 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pim\Bundle\CustomEntityBundle\Connector\Job\JobParameters\DefaultValuesProvider;
 
 use Akeneo\Tool\Component\Batch\Job\JobInterface;
 use Akeneo\Tool\Component\Batch\Job\JobParameters\DefaultValuesProviderInterface;
+use Akeneo\Tool\Component\Localization\Localizer\LocalizerInterface;
+
+use function in_array;
+use function sys_get_temp_dir;
 
 /**
  * Default value provider for reference data list
@@ -14,38 +20,43 @@ use Akeneo\Tool\Component\Batch\Job\JobParameters\DefaultValuesProviderInterface
  */
 class ReferenceData implements DefaultValuesProviderInterface
 {
-    /** @var DefaultValuesProviderInterface */
-    protected $simpleProvider;
-
     /** @var string[] */
-    protected $supportedJobNames;
+    protected array $supportedJobNames;
 
     /**
-     * @param DefaultValuesProviderInterface $simpleProvider
-     * @param string[]                       $supportedJobNames
+     * @param string[] $supportedJobNames
      */
-    public function __construct(DefaultValuesProviderInterface $simpleProvider, array $supportedJobNames)
+    public function __construct(array $supportedJobNames)
     {
-        $this->simpleProvider    = $simpleProvider;
         $this->supportedJobNames = $supportedJobNames;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getDefaultValues()
+    public function getDefaultValues(): array
     {
-        $defaultValues = $this->simpleProvider->getDefaultValues();
-        $defaultValues['reference_data_name'] = null;
-
-        return $defaultValues;
+        return [
+            'reference_data_name'   => null,
+            'storage' => [
+                'type' => 'csv',
+                'file_path' => sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'export_%job_label%_%datetime%.csv',
+            ],
+            'decimal_separator'     => LocalizerInterface::DEFAULT_DECIMAL_SEPARATOR,
+            'date_format'           => LocalizerInterface::DEFAULT_DATE_FORMAT,
+            'delimiter'             => ';',
+            'enclosure'             => '"',
+            'withHeader'            => true,
+            'users_to_notify'       => [],
+            'is_user_authenticated' => false,
+        ];
     }
 
     /**
      * {@inheritdoc}
      */
-    public function supports(JobInterface $job)
+    public function supports(JobInterface $job): bool
     {
-        return in_array($job->getName(), $this->supportedJobNames);
+        return in_array($job->getName(), $this->supportedJobNames, true);
     }
 }

--- a/Connector/Job/JobParameters/DefaultValuesProvider/ReferenceData.php
+++ b/Connector/Job/JobParameters/DefaultValuesProvider/ReferenceData.php
@@ -39,7 +39,7 @@ class ReferenceData implements DefaultValuesProviderInterface
         return [
             'reference_data_name'   => null,
             'storage' => [
-                'type' => 'csv',
+                'type' => 'local',
                 'file_path' => sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'export_%job_label%_%datetime%.csv',
             ],
             'decimal_separator'     => LocalizerInterface::DEFAULT_DECIMAL_SEPARATOR,

--- a/Connector/Job/JobParameters/DefaultValuesProvider/ReferenceData.php
+++ b/Connector/Job/JobParameters/DefaultValuesProvider/ReferenceData.php
@@ -47,6 +47,7 @@ class ReferenceData implements DefaultValuesProviderInterface
             'delimiter'             => ';',
             'enclosure'             => '"',
             'withHeader'            => true,
+            'uploadAllowed'         => false,
             'users_to_notify'       => [],
             'is_user_authenticated' => false,
         ];

--- a/DependencyInjection/PimCustomEntityExtension.php
+++ b/DependencyInjection/PimCustomEntityExtension.php
@@ -1,23 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pim\Bundle\CustomEntityBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
-/**
- * This is the class that loads and manages your bundle configuration
- *
- * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
- */
-class PimCustomEntityExtension extends Extension
+use function array_merge;
+use function array_pop;
+
+class PimCustomEntityExtension extends Extension implements PrependExtensionInterface
 {
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
@@ -34,5 +35,22 @@ class PimCustomEntityExtension extends Extension
         $loader->load('serializer.yml');
         $loader->load('services.yml');
         $loader->load('update_guessers.yml');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepend(ContainerBuilder $container): void
+    {
+        if (!$container->hasExtension('doctrine_migrations')) {
+            return;
+        }
+
+        $doctrineConfig = $container->getExtensionConfig('doctrine_migrations');
+        $container->prependExtensionConfig('doctrine_migrations', [
+            'migrations_paths' => array_merge(array_pop($doctrineConfig)['migrations_paths'] ?? [], [
+                'Pim\Bundle\CustomEntityBundle\Migrations' => '@PimCustomEntityBundle/Migrations',
+            ]),
+        ]);
     }
 }

--- a/Migrations/Version_7_0_20240806_update_job_instance_parameter_path.php
+++ b/Migrations/Version_7_0_20240806_update_job_instance_parameter_path.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CustomEntityBundle\Migrations;
+
+use Akeneo\Platform\Bundle\PimVersionBundle\VersionProviderInterface;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+final class Version_7_0_20240806_update_job_instance_parameter_path extends AbstractMigration implements ContainerAwareInterface
+{
+    private ?ContainerInterface $container;
+
+    public function setContainer(ContainerInterface $container = null): void
+    {
+        $this->container = $container;
+    }
+
+    public function up(Schema $schema): void
+    {
+        $jobInstances = $this->getJobInstances();
+
+        foreach ($jobInstances as $jobInstance) {
+            $rawParameters = unserialize($jobInstance['raw_parameters']);
+            $migratedRawParameters = $this->migrateRawParameters($rawParameters);
+
+            $this->updateJobInstance($jobInstance['id'], serialize($migratedRawParameters));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    private function getJobInstances(): array
+    {
+        $connection = $this->container->get('database_connection');
+        $sql = <<<SQL
+SELECT id, raw_parameters
+FROM akeneo_batch_job_instance
+WHERE connector = '{$this->container->getParameter('pim_custom_entity.connector_name.csv')}'
+AND type IN ('import', 'export')
+SQL;
+
+        $stmt = $connection->executeQuery($sql);
+
+        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+    }
+
+    private function migrateRawParameters(array $rawParameters): array
+    {
+        if (!array_key_exists('filePath', $rawParameters)) {
+            return $rawParameters;
+        }
+
+        $rawParameters['storage']['type'] = $this->isSaaSVersion() ? 'none' : 'local';
+        $rawParameters['storage']['file_path'] = $rawParameters['filePath'];
+
+        unset($rawParameters['filePath']);
+
+        return $rawParameters;
+    }
+
+    private function updateJobInstance(string $jobInstanceId, string $serializedRawParameters): void
+    {
+        $sql = <<<SQL
+UPDATE akeneo_batch_job_instance
+SET raw_parameters = :raw_parameters
+WHERE id = :job_instance_id
+SQL;
+
+        $this->addSql($sql, ['job_instance_id' => $jobInstanceId, 'raw_parameters' => $serializedRawParameters]);
+    }
+
+    private function isSaaSVersion(): bool
+    {
+        /** @var VersionProviderInterface $versionProvider */
+        $versionProvider = $this->container->get('pim_catalog.version_provider');
+
+        return $versionProvider->isSaaSVersion();
+    }
+}

--- a/Migrations/Version_7_0_20240806_update_job_instance_parameter_user_to_notify.php
+++ b/Migrations/Version_7_0_20240806_update_job_instance_parameter_user_to_notify.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CustomEntityBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+final class Version_7_0_20240806_update_job_instance_parameter_user_to_notify extends AbstractMigration implements ContainerAwareInterface
+{
+    private ?ContainerInterface $container;
+
+    public function setContainer(ContainerInterface $container = null): void
+    {
+        $this->container = $container;
+    }
+
+    public function up(Schema $schema): void
+    {
+        $jobInstancesToMigrate = $this->getJobInstancesToMigrate();
+
+        if (empty($jobInstancesToMigrate)) {
+            $this->write('No remaining job instance to migrate');
+
+            return;
+        }
+
+        foreach ($jobInstancesToMigrate as $jobInstance) {
+            $rawParameters = unserialize($jobInstance['raw_parameters']);
+            $migratedRawParameters = $this->migrateRawParameters($rawParameters);
+
+            $this->updateJobInstance($jobInstance['id'], serialize($migratedRawParameters));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    private function getJobInstancesToMigrate(): array
+    {
+        $connection = $this->container->get('database_connection');
+        $sql = <<<SQL
+SELECT id, raw_parameters
+FROM akeneo_batch_job_instance
+WHERE connector = '{$this->container->getParameter('pim_custom_entity.connector_name.csv')}'
+AND type IN ('import', 'export')
+SQL;
+
+        $stmt = $connection->executeQuery($sql);
+        $jobInstances = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        return array_filter($jobInstances, function (array $jobInstance) {
+            $rawParameters = unserialize($jobInstance['raw_parameters']);
+            return array_key_exists('user_to_notify', $rawParameters);
+        });
+    }
+
+    private function migrateRawParameters(array $rawParameters): array
+    {
+        $rawParameters['users_to_notify'] = null !== $rawParameters['user_to_notify'] ? [$rawParameters['user_to_notify']] : [];
+        unset($rawParameters['user_to_notify']);
+
+        return $rawParameters;
+    }
+
+    private function updateJobInstance(string $jobInstanceId, string $serializedRawParameters): void
+    {
+        $sql = <<<SQL
+UPDATE akeneo_batch_job_instance
+SET raw_parameters = :raw_parameters
+WHERE id = :job_instance_id
+SQL;
+
+        $this->addSql($sql, ['job_instance_id' => $jobInstanceId, 'raw_parameters' => $serializedRawParameters]);
+    }
+}

--- a/Resources/config/form_extensions/reference_data_csv_export_edit.yml
+++ b/Resources/config/form_extensions/reference_data_csv_export_edit.yml
@@ -98,15 +98,14 @@ extensions:
             tooltip: pim_custom_entity.export.csv.entity_name.help
 
     reference-data-job-instance-csv-export-edit-properties-file-path:
-        module: pim/job/common/edit/field/text
+        module: pimimportexport/js/job/common/edit/storage-form
         parent: reference-data-job-instance-csv-export-edit-global
         position: 105
-        targetZone: properties
+        targetZone: additional-properties
         config:
-            fieldCode: configuration.filePath
-            readOnly: false
-            label: pim_import_export.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
+            tabCode: pim-job-instance-properties
+            jobType: export
+            fileExtension: csv
 
     reference-data-job-instance-csv-export-edit-properties-decimal-separator:
         module: pim/job/common/edit/field/decimal-separator

--- a/Resources/config/form_extensions/reference_data_csv_import_edit.yml
+++ b/Resources/config/form_extensions/reference_data_csv_import_edit.yml
@@ -97,16 +97,15 @@ extensions:
             label: pim_custom_entity.import.csv.entity_name.label
             tooltip: pim_custom_entity.import.csv.entity_name.help
 
-    reference-data-job-instance-csv-import-edit-properties-file-path:
-        module: pim/job/common/edit/field/text
+    pim-job-instance-csv-product-import-edit-properties-storage:
+        module: pimimportexport/js/job/common/edit/storage-form
         parent: reference-data-job-instance-csv-import-edit-global
         position: 120
-        targetZone: properties
+        targetZone: additional-properties
         config:
-            fieldCode: configuration.filePath
-            readOnly: false
-            label: pim_import_export.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.title
+            tabCode: pim-job-instance-properties
+            jobType: import
+            fileExtension: csv
 
     reference-data-job-instance-csv-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/switch

--- a/Resources/config/form_extensions/reference_data_csv_import_edit.yml
+++ b/Resources/config/form_extensions/reference_data_csv_import_edit.yml
@@ -97,7 +97,7 @@ extensions:
             label: pim_custom_entity.import.csv.entity_name.label
             tooltip: pim_custom_entity.import.csv.entity_name.help
 
-    pim-job-instance-csv-product-import-edit-properties-storage:
+    reference-data-job-instance-csv-import-edit-properties-storage:
         module: pimimportexport/js/job/common/edit/storage-form
         parent: reference-data-job-instance-csv-import-edit-global
         position: 120

--- a/Resources/config/form_extensions/reference_data_csv_import_show.yml
+++ b/Resources/config/form_extensions/reference_data_csv_import_show.yml
@@ -38,6 +38,7 @@ extensions:
         position: 40
         config:
             label: pim_import_export.form.job_instance.button.import.launch
+            hideForCloudEdition: true
 
     reference-data-job-instance-csv-import-show-file-path:
         module: pim/job/common/file-path
@@ -65,6 +66,7 @@ extensions:
         config:
             allowedKey: uploadAllowed
             label: pim_import_export.form.job_instance.button.import.upload_file
+            hideForCloudEdition: false
 
     reference-data-job-instance-csv-import-show-upload:
         module: pim/job/common/edit/upload
@@ -101,7 +103,7 @@ extensions:
         position: 100
 
     reference-data-job-instance-csv-import-show-edit:
-        module: pim/common/redirect
+        module: pim/job/common/edit-button
         parent: reference-data-job-instance-csv-import-show
         targetZone: buttons
         position: 100

--- a/Resources/config/job_parameters.yml
+++ b/Resources/config/job_parameters.yml
@@ -10,20 +10,20 @@ services:
     pim_custom_entity.job.job_parameters.constraint_collection_provider.reference_data_csv_import:
         class: '%pim_custom_entity.job.job_parameters.constraint_collection_provider.reference_data.class%'
         arguments:
-            - '@akeneo_pim_enrichment.job.job_parameters.constraint_collection_provider.simple_csv_import'
-            - '@pim_custom_entity.configuration.registry'
-            -
-                - '%pim_custom_entity.job_name.csv_reference_data_import%'
+            $configurationRegistry: '@pim_custom_entity.configuration.registry'
+            $supportedJobNames: [ '%pim_custom_entity.job_name.csv_reference_data_import%' ]
+            $decimalSeparators: '%pim_catalog.localization.decimal_separators%'
+            $dateFormats: '%pim_catalog.localization.date_formats%'
         tags:
             - { name: akeneo_batch.job.job_parameters.constraint_collection_provider }
 
     pim_custom_entity.job.job_parameters.constraint_collection_provider.reference_data_csv_export:
         class: '%pim_custom_entity.job.job_parameters.constraint_collection_provider.reference_data.class%'
         arguments:
-            - '@akeneo_pim_enrichment.job.job_parameters.constraint_collection_provider.simple_csv_export'
-            - '@pim_custom_entity.configuration.registry'
-            -
-                - '%pim_custom_entity.job_name.csv_reference_data_export%'
+            $configurationRegistry: '@pim_custom_entity.configuration.registry'
+            $supportedJobNames: [ '%pim_custom_entity.job_name.csv_reference_data_export%' ]
+            $decimalSeparators: '%pim_catalog.localization.decimal_separators%'
+            $dateFormats: '%pim_catalog.localization.date_formats%'
         tags:
             - { name: akeneo_batch.job.job_parameters.constraint_collection_provider }
 
@@ -40,7 +40,6 @@ services:
     pim_custom_entity.job.job_parameters.default_values_provider.reference_data_csv_import:
         class: '%pim_custom_entity.job.job_parameters.default_values_provider.reference_data.class%'
         arguments:
-            - '@akeneo_pim_enrichment.job.job_parameters.default_values_provider.simple_csv_import'
             -
                 - '%pim_custom_entity.job_name.csv_reference_data_import%'
         tags:
@@ -49,7 +48,6 @@ services:
     pim_custom_entity.job.job_parameters.default_values_provider.reference_data_csv_export:
         class: '%pim_custom_entity.job.job_parameters.default_values_provider.reference_data.class%'
         arguments:
-            - '@akeneo_pim_enrichment.job.job_parameters.default_values_provider.simple_csv_export'
             -
                 - '%pim_custom_entity.job_name.csv_reference_data_export%'
         tags:

--- a/Resources/config/jobs.yml
+++ b/Resources/config/jobs.yml
@@ -45,6 +45,7 @@ services:
             - '@event_dispatcher'
             - '@akeneo_batch.job_repository'
             -
+                - '@akeneo.job_automation.connector.step.download'
                 - '@pim_connector.step.charset_validator'
                 - '@pim_custom_entity.step.csv_reference_data_import'
         tags:

--- a/Resources/public/js/field/select2.js
+++ b/Resources/public/js/field/select2.js
@@ -49,16 +49,18 @@ define(
              * {@inheritdoc}
              */
             render: function () {
-                if (!this.getFormData().configuration.reference_data_name) {
-                    if (!this.config.value) {
+                var currentValue = propertyAccessor.accessProperty(this.getFormData(), this.getFieldCode());
+                if (!currentValue && this.config.options && !_.isEmpty(this.config.options)) {
+                    var firstOption = _.first(_.keys(this.config.options));
+                    if (firstOption) {
                         this.config.value = _.first(_.keys(this.config.options));
                         const data = propertyAccessor.updateProperty(
                             this.getFormData(),
                             this.getFieldCode(),
-                            this.config.value
+                            firstOption
                         );
 
-                        this.setData(data);
+                        this.setData(data, {silent: true});
                     }
                 }
                 BaseField.prototype.render.apply(this, arguments);

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=8.0.0",
-        "akeneo/pim-community-dev": "^7.0.0"
+        "akeneo/pim-community-dev": "^7.0.0",
+        "ext-pdo": "*"
     },
     "require-dev": {
         "phpspec/phpspec": "^7.0",
@@ -27,6 +28,11 @@
         "psr-4": {
             "Pim\\Bundle\\CustomEntityBundle\\": "",
             "Acme\\Bundle\\CustomBundle\\": "docs/examples/CustomBundle"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "symfony/flex": true
         }
     }
 }


### PR DESCRIPTION
Fix some bugs while creating new import profiles. With those fixes you are able to just hit save and the profile will be saved. 

Fixed the following:

  1. uploadAllowed missing from constraint → added 'uploadAllowed'
  2. enclosure double-nested array bug → was [[NotBlank, Choice]] (array of arrays, constraints never ran), fixed to [NotBlank, Choice]
  3. Removed the default value as CSV for storage which does not exist on v7
  4. Fix csv_reference_data_import job which is missing the DownloadStep that Akeneo 7 requires before the charset validator.

<img width="500" height="188" alt="Screenshot 2026-04-07 at 14 03 09" src="https://github.com/user-attachments/assets/ae49d0cb-5a16-4094-a296-4b4b4431385c" />

<img width="500" height="133" alt="Screenshot 2026-04-07 at 14 37 17" src="https://github.com/user-attachments/assets/7f82b41a-f045-441f-9173-b598dd9d591d" />
